### PR TITLE
Fix for New() and Empty-field on record struct

### DIFF
--- a/src/Strongly/SourceGenerationHelper.cs
+++ b/src/Strongly/SourceGenerationHelper.cs
@@ -138,8 +138,16 @@ static class SourceGenerationHelper
             var ctorIndex =
                 baseDef.IndexOf(EmbeddedSources.CtorKey, StringComparison.InvariantCulture);
 
+            var emptyMethodIndex =
+                baseDef.IndexOf("public static readonly TYPENAME Empty =", StringComparison.InvariantCulture);
+
+            var emptyMethod = emptyMethodIndex == -1
+                ? ""
+                : baseDef.Substring(emptyMethodIndex) + Environment.NewLine;
+
             baseDef = baseDef
-                          .Substring(0, ctorIndex + EmbeddedSources.CtorKey.Length)
+                          .Substring(0, ctorIndex + EmbeddedSources.CtorValueKey.Length)
+                          .Insert(ctorIndex, emptyMethod)
                           .Replace("readonly partial struct", "readonly partial record struct")
                       + Environment.NewLine;
         }

--- a/src/Strongly/Templates/BigInteger/BigInteger_Base.cs
+++ b/src/Strongly/Templates/BigInteger/BigInteger_Base.cs
@@ -1,4 +1,4 @@
-﻿    public static readonly TYPENAME Empty = new TYPENAME(System.Numerics.BigInteger.Zero);
+﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
 
-    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
-    
+    public static readonly TYPENAME Empty = new TYPENAME(System.Numerics.BigInteger.Zero);
+       

--- a/src/Strongly/Templates/Decimal/Decimal_Base.cs
+++ b/src/Strongly/Templates/Decimal/Decimal_Base.cs
@@ -1,3 +1,3 @@
-﻿        public static readonly TYPENAME Empty = new TYPENAME(decimal.Zero);
+﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value); 
 
-        public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
+    public static readonly TYPENAME Empty = new TYPENAME(decimal.Zero);

--- a/src/Strongly/Templates/Double/Double_Base.cs
+++ b/src/Strongly/Templates/Double/Double_Base.cs
@@ -1,3 +1,4 @@
-﻿        public static readonly TYPENAME Empty = new TYPENAME(0.0);
+﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
 
-        public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
+    public static readonly TYPENAME Empty = new TYPENAME(0.0);
+  

--- a/src/Strongly/Templates/Float/Float_Base.cs
+++ b/src/Strongly/Templates/Float/Float_Base.cs
@@ -1,3 +1,4 @@
-﻿        public static readonly TYPENAME Empty = new TYPENAME(0f);
+﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
 
-        public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
+    public static readonly TYPENAME Empty = new TYPENAME(0f);
+  

--- a/src/Strongly/Templates/Guid/Guid_Base.cs
+++ b/src/Strongly/Templates/Guid/Guid_Base.cs
@@ -1,7 +1,6 @@
-﻿    
-    [NEW_METHOD]
-    
-    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
-    
+﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
+
     public static readonly TYPENAME Empty = new TYPENAME(System.Guid.Empty);
+
+    [NEW_METHOD]
     

--- a/src/Strongly/Templates/Long/Long_Base.cs
+++ b/src/Strongly/Templates/Long/Long_Base.cs
@@ -1,2 +1,3 @@
 ﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
+
     public static readonly TYPENAME Empty = new TYPENAME(0);

--- a/src/Strongly/Templates/NewId/NewId_Base.cs
+++ b/src/Strongly/Templates/NewId/NewId_Base.cs
@@ -1,5 +1,6 @@
 ﻿    public bool Equals(TYPENAME other) => this.Value.Equals(other.Value);
-    
+
+    public static readonly TYPENAME Empty = new TYPENAME(MassTransit.NewId.Empty); 
+
     public static TYPENAME New() => new TYPENAME(MassTransit.NewId.Next());
-    public static readonly TYPENAME Empty = new TYPENAME(MassTransit.NewId.Empty);
-    
+

--- a/test/Strongly.Tests/BigIntegerIdTests.cs
+++ b/test/Strongly.Tests/BigIntegerIdTests.cs
@@ -19,6 +19,12 @@ public class BigIntegerIdTests
     static readonly BigInteger BigN = BigInteger.Parse(BigNString);
 
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordBigIntegerId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = new BigInteger(123L);

--- a/test/Strongly.Tests/ByteIdTests.cs
+++ b/test/Strongly.Tests/ByteIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class ByteIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = ByteId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         byte id = 123;

--- a/test/Strongly.Tests/DecimalIdTests.cs
+++ b/test/Strongly.Tests/DecimalIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class DecimalIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordDecimalId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = 123.789M;

--- a/test/Strongly.Tests/DefaultIdTests.cs
+++ b/test/Strongly.Tests/DefaultIdTests.cs
@@ -13,6 +13,13 @@ namespace Strongly.IntegrationTests;
 public class DefaultIdTests
 {
     [Fact]
+    public void RecordHaveEmptyAndNew()
+    {
+        _ = RecordDefaultId1.New();
+        _ = RecordDefaultId1.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = Guid.NewGuid();

--- a/test/Strongly.Tests/DoubleIdTests.cs
+++ b/test/Strongly.Tests/DoubleIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class DoubleIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordDoubleId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = 123.789;

--- a/test/Strongly.Tests/FloatIdTests.cs
+++ b/test/Strongly.Tests/FloatIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class FloatIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordFloatId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = 123.789f;

--- a/test/Strongly.Tests/GuidCombIdTests.cs
+++ b/test/Strongly.Tests/GuidCombIdTests.cs
@@ -16,6 +16,13 @@ namespace Strongly.IntegrationTests;
 public class GuidCombIdTests
 {
     [Fact]
+    public void RecordHaveEmptyAndNew()
+    {
+        _ = RecordGuidCombId1.New();
+        _ = RecordGuidCombId1.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = NewId.NextGuid();

--- a/test/Strongly.Tests/GuidIdTests.cs
+++ b/test/Strongly.Tests/GuidIdTests.cs
@@ -437,6 +437,13 @@ public class GuidIdTests
     }
 
     [Fact]
+    public void RecordHaveNewAndEmpty()
+    {
+        _ = RecordGuidId1.New();
+        _ = RecordGuidId1.Empty;
+    }
+
+    [Fact]
     public void ImplicitCasts()
     {
         var value = Guid.NewGuid();

--- a/test/Strongly.Tests/IntIdTests.cs
+++ b/test/Strongly.Tests/IntIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class IntIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordIntId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = 123;

--- a/test/Strongly.Tests/LongIdTests.cs
+++ b/test/Strongly.Tests/LongIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class LongIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordLongId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = 123L;

--- a/test/Strongly.Tests/MassTransitNewIdTests.cs
+++ b/test/Strongly.Tests/MassTransitNewIdTests.cs
@@ -16,6 +16,13 @@ namespace Strongly.IntegrationTests;
 public class MassTransitNewIdTests
 {
     [Fact]
+    public void RecordHaveEmptyAndNew()
+    {
+        _ = RecordNewIdId1.Empty;
+        _ = RecordNewIdId1.New();
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = NewId.Next();

--- a/test/Strongly.Tests/NativeIntIdTests.cs
+++ b/test/Strongly.Tests/NativeIntIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class NativeIntIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordNativeIntId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         nint id = 123;

--- a/test/Strongly.Tests/SequentialGuidIdTests.cs
+++ b/test/Strongly.Tests/SequentialGuidIdTests.cs
@@ -16,6 +16,13 @@ namespace Strongly.IntegrationTests;
 public class SequentialGuidIdTests
 {
     [Fact]
+    public void RecordHaveEmptyAndNew()
+    {
+        _ = RecordSequentialGuidId1.New();
+        _ = RecordSequentialGuidId1.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         var id = NewId.NextGuid();

--- a/test/Strongly.Tests/ShortIdTests.cs
+++ b/test/Strongly.Tests/ShortIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class ShortIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordShortId.Empty;
+    }
+
+    [Fact]
     public void SameValuesAreEqual()
     {
         short id = 123;

--- a/test/Strongly.Tests/StringIdTests.cs
+++ b/test/Strongly.Tests/StringIdTests.cs
@@ -15,6 +15,12 @@ namespace Strongly.IntegrationTests;
 public class StringIdTests
 {
     [Fact]
+    public void RecordHaveEmpty()
+    {
+        _ = RecordStringId.Empty;
+    }
+
+    [Fact]
     public async Task ThrowsIfTryToCreateWithNull()
     {
         await Assert.ThrowsAsync<ArgumentNullException>(() =>

--- a/test/Strongly.Tests/Types/BigIntegerId.cs
+++ b/test/Strongly.Tests/Types/BigIntegerId.cs
@@ -5,6 +5,11 @@ partial struct BigIntegerId
 {
 }
 
+[Strongly(backingType: StronglyType.BigInteger)]
+partial record struct RecordBigIntegerId
+{
+}
+
 [Strongly(converters: StronglyConverter.None,
     backingType: StronglyType.BigInteger)]
 public partial struct NoConverterBigIntegerId

--- a/test/Strongly.Tests/Types/ByteId.cs
+++ b/test/Strongly.Tests/Types/ByteId.cs
@@ -5,6 +5,11 @@ public partial struct ByteId
 {
 }
 
+[Strongly(backingType: StronglyType.Byte)]
+public partial record struct RecordByteId
+{
+}
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.Byte)]
 public partial struct NoConverterByteId
 {

--- a/test/Strongly.Tests/Types/DecimalId.cs
+++ b/test/Strongly.Tests/Types/DecimalId.cs
@@ -5,6 +5,11 @@ public partial struct DecimalId
 {
 }
 
+[Strongly(backingType: StronglyType.Decimal)]
+public partial record struct RecordDecimalId
+{
+}
+
 [Strongly(converters: StronglyConverter.None,
     backingType: StronglyType.Decimal)]
 public partial struct NoConverterDecimalId

--- a/test/Strongly.Tests/Types/DefaultId.cs
+++ b/test/Strongly.Tests/Types/DefaultId.cs
@@ -10,6 +10,9 @@ namespace Strongly.IntegrationTests.Types;
 partial struct DefaultId1 { }
 
 [Strongly]
+partial record struct RecordDefaultId1 { }
+
+[Strongly]
 public partial struct DefaultId2 { }
 
 [Strongly(converters: StronglyConverter.None)]

--- a/test/Strongly.Tests/Types/DoubleId.cs
+++ b/test/Strongly.Tests/Types/DoubleId.cs
@@ -5,6 +5,11 @@ public partial struct DoubleId
 {
 }
 
+[Strongly(backingType: StronglyType.Double)]
+public partial record struct RecordDoubleId
+{
+}
+
 [Strongly(converters: StronglyConverter.None,
     backingType: StronglyType.Double)]
 public partial struct NoConverterDoubleId

--- a/test/Strongly.Tests/Types/FloatId.cs
+++ b/test/Strongly.Tests/Types/FloatId.cs
@@ -7,6 +7,11 @@ public partial struct FloatId
 {
 }
 
+[Strongly(backingType: StronglyType.Float)]
+public partial record struct RecordFloatId
+{
+}
+
 [Strongly(converters: StronglyConverter.None,
     backingType: StronglyType.Float)]
 public partial struct NoConverterFloatId

--- a/test/Strongly.Tests/Types/GuidCombId.cs
+++ b/test/Strongly.Tests/Types/GuidCombId.cs
@@ -1,6 +1,11 @@
 ﻿namespace Strongly.IntegrationTests.Types;
 
 [Strongly(backingType: StronglyType.GuidComb)]
+public partial record struct RecordGuidCombId1
+{
+}
+
+[Strongly(backingType: StronglyType.GuidComb)]
 public partial struct GuidCombId1
 {
 }

--- a/test/Strongly.Tests/Types/IntId.cs
+++ b/test/Strongly.Tests/Types/IntId.cs
@@ -5,6 +5,11 @@ public partial struct IntId
 {
 }
 
+[Strongly(backingType: StronglyType.Int)]
+public partial record struct RecordIntId
+{
+}
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.Int)]
 public partial struct NoConverterIntId
 {

--- a/test/Strongly.Tests/Types/LongId.cs
+++ b/test/Strongly.Tests/Types/LongId.cs
@@ -5,6 +5,11 @@ partial struct LongId
 {
 }
 
+[Strongly(backingType: StronglyType.Long)]
+partial record struct RecordLongId
+{
+}
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.Long)]
 public partial struct NoConverterLongId
 {

--- a/test/Strongly.Tests/Types/NIntId.cs
+++ b/test/Strongly.Tests/Types/NIntId.cs
@@ -5,6 +5,11 @@ public partial struct NativeIntId
 {
 }
 
+[Strongly(backingType: StronglyType.NativeInt)]
+public partial record struct RecordNativeIntId
+{
+}
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.NativeInt)]
 public partial struct NoConverterNativeIntId
 {

--- a/test/Strongly.Tests/Types/NewIdId.cs
+++ b/test/Strongly.Tests/Types/NewIdId.cs
@@ -4,6 +4,9 @@
 partial struct NewIdId1 { }
 
 [Strongly(backingType: StronglyType.MassTransitNewId)]
+partial record struct RecordNewIdId1 { }
+
+[Strongly(backingType: StronglyType.MassTransitNewId)]
 public partial struct NewIdId2 { }
 
 [Strongly(backingType: StronglyType.MassTransitNewId, converters: StronglyConverter.None)]

--- a/test/Strongly.Tests/Types/SequentialGuidId.cs
+++ b/test/Strongly.Tests/Types/SequentialGuidId.cs
@@ -6,6 +6,11 @@ public partial struct SequentialGuidId1
 }
 
 [Strongly(backingType: StronglyType.SequentialGuid)]
+public partial record struct RecordSequentialGuidId1
+{
+}
+
+[Strongly(backingType: StronglyType.SequentialGuid)]
 public partial struct SequentialGuidId2
 {
 }

--- a/test/Strongly.Tests/Types/ShortId.cs
+++ b/test/Strongly.Tests/Types/ShortId.cs
@@ -5,6 +5,11 @@ public partial struct ShortId
 {
 }
 
+[Strongly(backingType: StronglyType.Short)]
+public partial record struct RecordShortId
+{
+}
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.Short)]
 public partial struct NoConverterShortId
 {

--- a/test/Strongly.Tests/Types/StringId.cs
+++ b/test/Strongly.Tests/Types/StringId.cs
@@ -3,6 +3,9 @@
 [Strongly(backingType: StronglyType.String)]
 partial struct StringId { }
 
+[Strongly(backingType: StronglyType.String)]
+partial record struct RecordStringId { }
+
 [Strongly(converters: StronglyConverter.None, backingType: StronglyType.String)]
 public partial struct NoConvertersStringId { }
 


### PR DESCRIPTION
When using `record struct`, the `New()` method and the `Empty` public field was removed when cleaning up the baseDef.

I parse the `Empty` declaration, and `New()` declaration if present, and inserted before the constructor. So they wouldnt be removed later in the process.

I moved some of the methods in the (_TYPENAME_)_base.cs classes, so that the `Empty` field could serve as a delimiter on what to keep in the baseDef.

I also added some "dummy" test to see that the `Empty` and `New()` is generated correctly.